### PR TITLE
Add custom LZW compression format

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,13 @@ def update_image(self, *_):
     self.image_label.configure(image=self.photo)
 ```
 
+### Compression Support
+
+The GUI can compress any loaded BMP image using a custom LZW-based algorithm.
+Click **Compress to .cmpt365** to save the current image in the custom format.
+Compression statistics (original size, compressed size, ratio and time) are
+shown after saving. The `.cmpt365` header stores image dimensions, the original
+colour depth and the number of bytes used per LZW code (2–4), so decompression
+can reliably reconstruct the pixels. Use **Open .cmpt365…** to open and display
+a previously saved file. When a `.cmpt365` image is opened, the viewer shows
+the stored colour depth in the metadata table.

--- a/compression.py
+++ b/compression.py
@@ -1,0 +1,150 @@
+"""Simple LZW compression utilities for CMPT365 files."""
+
+from __future__ import annotations
+
+import time
+
+
+class LZW:
+    @staticmethod
+    def compress(data: bytes) -> tuple[bytes, int]:
+        """Compress bytes using a basic LZW algorithm.
+
+        Returns a tuple of (compressed_bytes, bytes_per_code)."""
+        # Initialize dictionary with single-byte entries
+        dictionary: dict[bytes, int] = {bytes([i]): i for i in range(256)}
+        next_code = 256
+        w = b""
+        codes: list[int] = []
+        max_code = 255
+        for byte in data:
+            k = bytes([byte])
+            wk = w + k
+            if wk in dictionary:
+                w = wk
+            else:
+                codes.append(dictionary[w])
+                dictionary[wk] = next_code
+                max_code = max(max_code, next_code)
+                next_code += 1
+                w = k
+        if w:
+            codes.append(dictionary[w])
+            max_code = max(max_code, dictionary[w])
+
+        if max_code <= 0xFFFF:
+            width = 2
+        elif max_code <= 0xFFFFFF:
+            width = 3
+        else:
+            width = 4
+
+        out = bytearray()
+        for code in codes:
+            out.extend(code.to_bytes(width, "big"))
+        return bytes(out), width
+
+    @staticmethod
+    def decompress(data: bytes, width: int) -> bytes:
+        """Decompress bytes produced by `compress` using ``width`` bytes per code."""
+        if width not in (2, 3, 4):
+            raise ValueError("Invalid code width")
+        if len(data) % width != 0:
+            raise ValueError("Corrupted LZW data length")
+        codes = [int.from_bytes(data[i:i+width], "big") for i in range(0, len(data), width)]
+        if not codes:
+            return b""
+        dictionary: dict[int, bytes] = {i: bytes([i]) for i in range(256)}
+        next_code = 256
+
+        w = dictionary[codes[0]]
+        result = bytearray(w)
+        for code in codes[1:]:
+            if code in dictionary:
+                entry = dictionary[code]
+            elif code == next_code:
+                entry = w + w[:1]
+            else:
+                raise ValueError("Bad compressed code")
+            result.extend(entry)
+            dictionary[next_code] = w + entry[:1]
+            next_code += 1
+            w = entry
+        return bytes(result)
+
+
+def save_cmpt365(
+    path: str,
+    width: int,
+    height: int,
+    bits_per_pixel: int,
+    pixels: bytes,
+) -> tuple[int, int, int]:
+    """Compress and save raw pixel bytes to a ``.cmpt365`` file.
+
+    ``bits_per_pixel`` records the original colour depth so the viewer can
+    display accurate metadata.  The pixel data itself is always stored as
+    bytes and compressed using LZW.
+
+    Returns ``(original_size, compressed_size, elapsed_ms)``.
+    """
+    start = time.perf_counter()
+    compressed, code_width = LZW.compress(pixels)
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+
+    header = bytearray()
+    header.extend(b"CMPT")  # magic
+    header.append(1)  # version
+    header.append(1)  # algorithm id for LZW
+    header.append(code_width)  # bytes per LZW code
+    header.append(bits_per_pixel & 0xFF)  # original colour depth
+    header.extend(width.to_bytes(4, "little"))
+    header.extend(height.to_bytes(4, "little"))
+    header.extend(len(compressed).to_bytes(4, "little"))
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(compressed)
+
+    return len(pixels), len(header) + len(compressed), elapsed_ms
+
+
+def load_cmpt365(path: str) -> tuple[int, int, int, bytes]:
+    """Load a ``.cmpt365`` file.
+
+    Returns ``(width, height, bits_per_pixel, pixel_bytes)``.
+    """
+    with open(path, "rb") as f:
+        magic = f.read(4)
+        if magic != b"CMPT":
+            raise ValueError("Invalid CMPT file")
+        version = int.from_bytes(f.read(1), "little")
+        alg = int.from_bytes(f.read(1), "little")
+        code_width = int.from_bytes(f.read(1), "little")
+        bits_per_pixel = int.from_bytes(f.read(1), "little")
+        width = int.from_bytes(f.read(4), "little")
+        height = int.from_bytes(f.read(4), "little")
+        data_len = int.from_bytes(f.read(4), "little")
+        data = f.read(data_len)
+        if len(data) < data_len:
+            raise ValueError("Truncated CMPT file")
+
+    if alg != 1:
+        raise ValueError("Unsupported compression algorithm")
+
+    pixels = LZW.decompress(data, code_width)
+
+    bytes_per_pixel = (bits_per_pixel + 7) // 8
+    expected = width * height * bytes_per_pixel
+    if len(pixels) != expected:
+        raise ValueError("Decompressed data size mismatch")
+
+    return width, height, bits_per_pixel, pixels
+
+
+def format_size(size: int) -> str:
+    if size < 1024:
+        return f"{size} bytes"
+    if size < 1024 * 1024:
+        return f"{size} bytes ({size/1024:.1f} KB)"
+    return f"{size} bytes ({size/1024/1024:.1f} MB)"


### PR DESCRIPTION
## Summary
- implement a simple LZW algorithm and utilities for the custom `.cmpt365` image format
- extend the GUI with buttons to open and save `.cmpt365` files
- show compression statistics after saving
- document the new feature
- fix overflow when compressing large images by using variable code widths
- save original color depth in `.cmpt365` files so the viewer can display accurate metadata

## Testing
- `venv/bin/python -m py_compile bmpapp.py compression.py BMPParser.py`


------
https://chatgpt.com/codex/tasks/task_e_6878752b8f608324ae7ee224a1e2eb16