### PR TITLE
Implement numpy-based compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ def update_image(self, *_):
 
 ### Compression Support
 
-The GUI can compress any loaded BMP image using a custom LZW-based algorithm.
+The GUI can compress any loaded BMP image using a custom LZMA-inspired
+algorithm implemented from scratch and accelerated with NumPy arrays.
 Click **Compress to .cmpt365** to save the current image in the custom format.
 Compression statistics (original size, compressed size, ratio and time) are
 
 shown after saving. Pixel data is stored using the image's original bits per
 pixel rather than being converted to 32‑bit, so files always decompress to the
 correct byte length. The `.cmpt365` header stores image dimensions, colour
-depth and the number of bytes used per LZW code (2–4). Use **Open .cmpt365…**
+depth and a small flag field. Use **Open .cmpt365…**
 to open and display a previously saved file. When a `.cmpt365` image is opened,
 the viewer shows the stored colour depth in the metadata table.

--- a/compression.py
+++ b/compression.py
@@ -4,6 +4,95 @@ from __future__ import annotations
 
 import time
 
+import numpy as np
+
+
+class LZMA:
+    """Very small LZMA-like compressor using a simple LZ77 scheme.
+
+    This is **not** a full LZMA implementation but provides a minimal
+    dictionary based compressor so the application can operate without
+    external libraries.
+    """
+
+    WINDOW_SIZE = 4096
+    MIN_MATCH = 3
+    MAX_MATCH = 255
+
+    @staticmethod
+    def _match_length(arr: np.ndarray, pos: int, dist: int) -> int:
+        """Return match length of ``arr[pos:]`` with ``arr[pos-dist:]``."""
+        max_len = min(LZMA.MAX_MATCH, arr.size - pos, dist)
+        if max_len <= 0:
+            return 0
+        a = arr[pos : pos + max_len]
+        b = arr[pos - dist : pos - dist + max_len]
+        cmp = a == b
+        # find index of first mismatch
+        if not np.all(cmp):
+            return int(np.argmax(~cmp))
+        return int(max_len)
+
+    @staticmethod
+    def compress(data: bytes) -> bytes:
+        """Compress ``data`` using a small LZ77 scheme accelerated with NumPy."""
+        arr = np.frombuffer(data, dtype=np.uint8)
+        out = bytearray()
+        i = 0
+        n = arr.size
+        while i < n:
+            window_start = max(0, i - LZMA.WINDOW_SIZE)
+            match_len = 0
+            match_dist = 0
+            for dist in range(1, i - window_start + 1):
+                length = LZMA._match_length(arr, i, dist)
+                if length > match_len:
+                    match_len = length
+                    match_dist = dist
+                    if match_len == LZMA.MAX_MATCH:
+                        break
+            if match_len >= LZMA.MIN_MATCH:
+                out.append(1)
+                out.extend(match_dist.to_bytes(2, "big"))
+                out.append(match_len)
+                i += match_len
+            else:
+                out.append(0)
+                out.append(int(arr[i]))
+                i += 1
+        return bytes(out)
+
+    @staticmethod
+    def decompress(data: bytes) -> bytes:
+        """Decompress bytes produced by :meth:`compress`."""
+        arr = np.frombuffer(data, dtype=np.uint8)
+        out = bytearray()
+        i = 0
+        n = arr.size
+        while i < n:
+            flag = int(arr[i])
+            i += 1
+            if flag == 0:
+                if i >= n:
+                    raise ValueError("Corrupted LZMA data")
+                out.append(int(arr[i]))
+                i += 1
+            elif flag == 1:
+                if i + 2 >= n:
+                    raise ValueError("Corrupted LZMA data")
+                dist = (int(arr[i]) << 8) | int(arr[i + 1])
+                i += 2
+                match_len = int(arr[i])
+                i += 1
+                if dist == 0 or match_len == 0 or dist > len(out):
+                    raise ValueError("Corrupted LZMA data")
+                start = len(out) - dist
+                segment = np.frombuffer(bytes(out), dtype=np.uint8)[start : start + match_len]
+                out.extend(segment.tobytes())
+            else:
+                raise ValueError("Invalid LZMA flag")
+        return bytes(out)
+
 
 class LZW:
     @staticmethod
@@ -84,19 +173,20 @@ def save_cmpt365(
 
     ``bits_per_pixel`` records the original colour depth so the viewer can
     display accurate metadata.  The pixel data itself is always stored as
-    bytes and compressed using LZW.
+    bytes and compressed using a simplified LZMA implementation.
 
     Returns ``(original_size, compressed_size, elapsed_ms)``.
     """
     start = time.perf_counter()
-    compressed, code_width = LZW.compress(pixels)
+    compressed = LZMA.compress(pixels)
+    code_width = 0  # not used by this implementation
     elapsed_ms = int((time.perf_counter() - start) * 1000)
 
     header = bytearray()
     header.extend(b"CMPT")  # magic
     header.append(1)  # version
-    header.append(1)  # algorithm id for LZW
-    header.append(code_width)  # bytes per LZW code
+    header.append(2)  # algorithm id for LZMA
+    header.append(code_width)  # unused for LZMA
     header.append(bits_per_pixel & 0xFF)  # original colour depth
     header.extend(width.to_bytes(4, "little"))
     header.extend(height.to_bytes(4, "little"))
@@ -129,10 +219,12 @@ def load_cmpt365(path: str) -> tuple[int, int, int, bytes]:
         if len(data) < data_len:
             raise ValueError("Truncated CMPT file")
 
-    if alg != 1:
+    if alg == 1:
+        pixels = LZW.decompress(data, code_width)
+    elif alg == 2:
+        pixels = LZMA.decompress(data)
+    else:
         raise ValueError("Unsupported compression algorithm")
-
-    pixels = LZW.decompress(data, code_width)
 
     bytes_per_pixel = (bits_per_pixel + 7) // 8
     expected = width * height * bytes_per_pixel


### PR DESCRIPTION
## Summary
- refactor simplified LZMA compressor to use NumPy
- update README about NumPy acceleration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from compression import LZMA
s = b'ABABABABABABABABABABABABABABABABABABABABABABABABABAB'
c = LZMA.compress(s)
print('compressed length', len(c))
d = LZMA.decompress(c)
print('ok', d==s)
PY`
- `python - <<'PY'
from compression import save_cmpt365, load_cmpt365
import os
pixels = bytes([255,0,0, 0,255,0, 0,0,255, 255,255,255])
orig, comp, ms = save_cmpt365('test.cmpt365',2,2,24,pixels)
print(orig, comp, ms)
w,h,bpp,data = load_cmpt365('test.cmpt365')
print(w,h,bpp,data)
os.remove('test.cmpt365')
PY`


------
https://chatgpt.com/codex/tasks/task_e_687889749ebc832497f00ce7e1cec4a1